### PR TITLE
Refactor code for checking simulation exit status

### DIFF
--- a/training/erbb_network_jl/simulation.jl
+++ b/training/erbb_network_jl/simulation.jl
@@ -44,7 +44,7 @@ function solveode(
             prob,CVODE_BDF(),
             abstol=ABSTOL,reltol=RELTOL,saveat=dt,dtmin=eps(),verbose=false
         )
-        is_successful = ifelse(sol.retcode === :Success, true, false)
+        is_successful = ifelse(sol.retcode == :Success, true, false)
     catch
         is_successful = false
     finally
@@ -71,7 +71,7 @@ function get_steady_state(
             ),
             dt=dt,verbose=false
         )
-        is_successful = ifelse(sol.retcode === :Success, true, false)
+        is_successful = ifelse(sol.retcode == :Success, true, false)
     catch
         is_successful = false
     finally


### PR DESCRIPTION
Hello @himoto! I hope this finds you well.

While reproducing the results in this repository, we found that the code gets stuck in an infinite loop during [the parameter estimation step](https://pasmopy.github.io/breast_cancer/getting-started/individualization.html).
More specifically, it was failing to generate the initial values for the parameters, causing the code to retry indefinitely.

After some investigation, I think I have pinned down the cause of this problem to the line that checked the exit status of the simulation: `is_successful = ifelse(sol.retcode === :Success, true, false)`
Changing the comparison operator to a *looser* `==` fixed the problem.

It's a very subtle change, but I thought I'd push this in case anyone else wants to reproduce the results.